### PR TITLE
topページからユーザー新規作成ページに遷移できるように修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,8 @@ AsciiComments:
  Enabled: false
 Style/Documentation:
   Enabled: false
+ClassAndModuleChildren:
+  EnforcedStyle: compact
+Rails/TopLevelInclude:
+  Include:
+    - app/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -35,29 +35,29 @@ gem 'bcrypt', '~> 3.1.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'factory_bot_rails', '~> 4.11'
+gem 'kaminari'
 gem 'rails_autolink'
 gem 'rails_best_practices', require: false
-gem 'factory_bot_rails', '~> 4.11'
 gem 'ransack'
-gem 'kaminari'
 gem 'webpacker'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i(mri mingw x64_mingw)
-  gem 'pry-rails'
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'pry-byebug'
   gem 'pry-doc'
+  gem 'pry-rails'
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
+  gem 'rubocop', '~> 0.64.0', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'rubocop', '~> 0.64.0', require: false
 end
 
 group :test do
@@ -70,9 +70,9 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i(mingw mswin x64_mingw jruby)
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-gem 'slim-rails'
 gem 'html2slim'
+gem 'slim-rails'
 
-gem "bootstrap", ">= 4.3.1"
+gem 'bootstrap', '>= 4.3.1'

--- a/app/assets/javascripts/signup.coffee
+++ b/app/assets/javascripts/signup.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the signup controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < ApplicationController
   before_action :login_required
-  
+
   def index
     @users = User.all.order(created_at: 'DESC')
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -47,6 +47,8 @@ class Admin::UsersController < ApplicationController
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
   end
 
+  # ここでadmin権限の確認を行なっている。サインアップ時には影響させないようにする。
+  # というか消していいのでは？
   def require_admin
     redirect_to root_path unless current_user.admin?
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < ApplicationController
-  before_action :require_admin
-
+  before_action :login_required
+  
   def index
     @users = User.all.order(created_at: 'DESC')
   end
@@ -16,7 +16,7 @@ class Admin::UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to admin_users_path(@user), notice: "ユーザー「#{@user.name}」を登録しました！"
+      redirect_to admin_users_path, notice: "ユーザー「#{@user.name}」を登録しました！"
     else
       render :new
     end
@@ -47,9 +47,8 @@ class Admin::UsersController < ApplicationController
     params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
   end
 
-  # ここでadmin権限の確認を行なっている。サインアップ時には影響させないようにする。
-  # というか消していいのでは？
-  def require_admin
-    redirect_to root_path unless current_user.admin?
-  end
+  # 作成されたユーザかの確認を行う
+  # def require_admin
+  #   redirect_to root_path unless current_user.admin?
+  # end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
+  # サインアップしていないユーザーがログインしようとすると弾いてしまうので削除？
   def login_required
     redirect_to login_path unless current_user
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,6 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
-  # サインアップしていないユーザーがログインしようとすると弾いてしまうので削除？
   def login_required
     redirect_to login_path unless current_user
   end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,0 +1,13 @@
+class SignupController < ApplicationController
+  before_action :set_user
+  skip_before_action :login_required
+
+  # signup時にユーザーを初期化する
+  def new
+    @user = User.new
+  end
+
+  def create; end
+
+  def destroy; end
+end

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,13 +1,23 @@
 class SignupController < ApplicationController
-  before_action :set_user
   skip_before_action :login_required
 
-  # signup時にユーザーを初期化する
   def new
     @user = User.new
   end
 
-  def create; end
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      redirect_to tasks_path, notice: "ユーザー「#{@user.name}」を登録しました！"
+    else
+      render :new
+    end
+  end
 
-  def destroy; end
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+  end
 end

--- a/app/helpers/signup_helper.rb
+++ b/app/helpers/signup_helper.rb
@@ -1,0 +1,2 @@
+module SignupHelper
+end

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -8,3 +8,6 @@ h1 ログイン
     = f.label :password, 'パスワード'
     = f.password_field :password, class: 'form-control', id: 'session-password'
   = f.submit 'ログインする', class: 'btn btn-primary'
+
+
+= link_to 'ここから新規作成', signup_path

--- a/app/views/signup/_form.html.slim
+++ b/app/views/signup/_form.html.slim
@@ -1,0 +1,21 @@
+/ ここのエラーメッセージの表示をモダンにしたい
+- if user.errors.present?
+  u1#error_explanation
+    - user.errors.full_messages.each do |message|
+      li = message
+
+= form_with model: [:admin, user], local: true do |f|
+  .form-group
+    = f.label :name, '名前'
+    = f.text_field :name, class: 'form-control'
+  .form-group
+    = f.label :email, 'メールアドレス'
+    = f.text_field :email, class: 'form-control'
+  .form-group
+    = f.label :password, 'パスワード'
+    = f.password_field :password, class: 'form-control'
+  .form-group
+    = f.label :password_confirmation, 'パスワード（確認）'
+    = f.password_field :password_confirmation, class: 'form-control'
+  = f.submit '登録する', class: 'btn btn-primary'
+  

--- a/app/views/signup/_form.html.slim
+++ b/app/views/signup/_form.html.slim
@@ -3,8 +3,8 @@
   u1#error_explanation
     - user.errors.full_messages.each do |message|
       li = message
-
-= form_with model: [:admin, user], local: true do |f|
+/ デフォルトでadminをfalseにして飛ばしたい      
+= form_with model: user, url: signup_path, local: true do |f|
   .form-group
     = f.label :name, '名前'
     = f.text_field :name, class: 'form-control'
@@ -17,5 +17,6 @@
   .form-group
     = f.label :password_confirmation, 'パスワード（確認）'
     = f.password_field :password_confirmation, class: 'form-control'
+  = f.hidden_field :admin
   = f.submit '登録する', class: 'btn btn-primary'
   

--- a/app/views/signup/new.html.slim
+++ b/app/views/signup/new.html.slim
@@ -1,0 +1,3 @@
+h1 ユーザー新規登録
+
+= render partial: 'form', locals: { user: @user }

--- a/bin/update
+++ b/bin/update
@@ -2,7 +2,6 @@
 include FileUtils
 require 'fileutils'
 
-
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
   get 'session/new'
+  get '/signup', to: 'signup#new'
   namespace :admin do
     resources :users
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy'
   get 'session/new'
   get '/signup', to: 'signup#new'
+  post '/signup', to: 'signup#create'
   namespace :admin do
     resources :users
   end

--- a/db/migrate/20181205143655_add_user_id_to_tasks.rb
+++ b/db/migrate/20181205143655_add_user_id_to_tasks.rb
@@ -1,10 +1,10 @@
 class AddUserIdToTasks < ActiveRecord::Migration[5.2]
   def up
     execute 'DELETE FROM tasks;'
-    add_reference :tasks, :user, null: :false, index: :true
+    add_reference :tasks, :user, null: false, index: true
   end
 
   def down
-    remove_reference :tasks, :user, index: :true
+    remove_reference :tasks, :user, index: true
   end
 end

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,4 +1,14 @@
 {
-  "application.js": "/packs/application-ef7dcf7cacaaf7f632c4.js",
-  "application.js.map": "/packs/application-ef7dcf7cacaaf7f632c4.js.map"
+  "application.js": "/packs/js/application-90eb402507887851ef86.js",
+  "application.js.map": "/packs/js/application-90eb402507887851ef86.js.map",
+  "entrypoints": {
+    "application": {
+      "js": [
+        "/packs/js/application-90eb402507887851ef86.js"
+      ],
+      "js.map": [
+        "/packs/js/application-90eb402507887851ef86.js.map"
+      ]
+    }
+  }
 }

--- a/spec/mailers/task_mailer_spec.rb
+++ b/spec/mailers/task_mailer_spec.rb
@@ -2,20 +2,18 @@
 require 'rails_helper'
 
 describe TaskMailer, type: :mailer do
-
   let(:task) { FactoryBot.create(:task, name: 'メイラーSpecを書く', description: '送信したメールの内容を確認します') }
 
   let(:text_body) do
-    part = mail.body.parts.detect { |part| part.content_type == 'text/plain; charset=UTF-8' }
+    part = mail.body.parts.detect { |pr_part| pr_part.content_type == 'text/plain; charset=UTF-8' }
     part.body.raw_source
   end
   let(:html_body) do
-    part = mail.body.parts.detect { |part| part.content_type == 'text/html; charset=UTF-8' }
+    part = mail.body.parts.detect { |pr_part| pr_part.content_type == 'text/html; charset=UTF-8' }
     part.body.raw_source
   end
 
   describe '#creation_email' do
-
     let(:mail) { TaskMailer.creation_email(task) }
 
     it '想定通りのメールが生成されている' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
-  
+
   # ドライバの設定
   config.before(:each, type: :system) do
     driven_by :selenium_chrome_headless

--- a/test/controllers/signup_controller_test.rb
+++ b/test/controllers/signup_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SignupControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Background / Why (背景と理由)

```
- topページからユーザーの新規作成が出来なかったので、今回から方針を変えてユーザー個人に権限を持たせて個人にタスクを紐づかせることとする。今回はその入口の実装となる
```

## What (やったこと)

```
- topページからユーザー新規作成画面に遷移し、そこでユーザーを新規に作成できるように修正
```

### Unscoped (まだやってないこと)[任意]

```
細かいデザイン部分の調整
```
